### PR TITLE
Biophysical models

### DIFF
--- a/pinot/regressors/biophysical_regressor.py
+++ b/pinot/regressors/biophysical_regressor.py
@@ -5,11 +5,6 @@ import torch
 import pinot
 import abc
 import math
-from pinot.regressors.base_regressor import BaseRegressor
-from pinot.regressors.gaussian_process_regressor import ExactGaussianProcessRegressor
-from pinot.regressors.neural_network_regressor import NeuralNetworkRegressor
-
-# import gpytorch
 import numpy as np
 
 class BiophysicalRegressor(torch.nn.Module):
@@ -29,32 +24,28 @@ class BiophysicalRegressor(torch.nn.Module):
     def __init__(self, base_regressor=None):
         super(BiophysicalRegressor, self).__init__()
         self.base_regressor = base_regressor
-        self.log_sigma_measurement = torch.zeros(1)
+        self.log_sigma_measurement = torch.nn.Parameter(torch.zeros(1))
 
 
-	def g(self, func_value=None, test_ligand_concentration=1e3-):
+	def g(self, func_value=None, test_ligand_concentration=1e-3):
 	    return 1 / (1 + torch.exp(-func_value) / test_ligand_concentration)
 
 
 	def condition(self, h=None, test_ligand_concentration=1e-3, **kwargs):
-        distribution_base_regressor = self.base_regressor.condition(h, kwargs)
-
-        #we sample from the latent f to paush things through the likelihood
-        #Note: if we do this, in order to get good estimates of LLK we may need to draw multiple samples
-        f_sample = distribution_base_regressor.rsample()
-
-        mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
-        sigma_m = torch.exp(self.log_sigma_measurement)
-
-        distribution_measurement = torch.distributions.normal.Normal(loc=mu_m, scale=sigma_m)
-
-        return distribution_measurement
+		distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
+		#we sample from the latent f to push things through the likelihood
+		#Note: if we do this, in order to get good estimates of LLK we may need to draw multiple samples
+		f_sample = distribution_base_regressor.rsample()
+		mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
+		sigma_m = torch.exp(self.log_sigma_measurement)
+		distribution_measurement = torch.distributions.normal.Normal(loc=mu_m, scale=sigma_m)
+		return distribution_measurement
 
 
-    def loss(self, h=None, y=None, test_ligand_concentration=1e-3, **kwargs):
-    	distribution_measurement = self.condition(h=h, test_ligand_concentration=test_ligand_concentration, kwargs)
-    	loss_measurement = -distribution_measurement.log_prob(y)
-    	return loss_measurement
+	def loss(self, h=None, y=None, test_ligand_concentration=1e-3, **kwargs):
+		distribution_measurement = self.condition(h=h, test_ligand_concentration=test_ligand_concentration, **kwargs)
+		loss_measurement = -distribution_measurement.log_prob(y)
+		return loss_measurement
 
 
    	def marginal_sample(self, h=None, n_samples=100, test_ligand_concentration=1e-3, **kwargs):
@@ -73,7 +64,7 @@ class BiophysicalRegressor(torch.nn.Module):
     	"""
     	sample n_samples often from loss in order to get a better approximation
     	"""
-    	distribution_base_regressor = self.base_regressor.condition(h, kwargs)
+    	distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
     	marginal_loss_measurement = 0
     	for ns in range(n_samples):
     		for ns in range(n_samples):

--- a/pinot/regressors/biophysical_regressor.py
+++ b/pinot/regressors/biophysical_regressor.py
@@ -57,6 +57,20 @@ class BiophysicalRegressor(torch.nn.Module):
     	return loss_measurement
 
 
+   	def marginal_sample(self, h=None, n_samples=100, test_ligand_concentration=1e-3, **kwargs):
+   		"""
+   		Note:
+   		This is currently inefficient bebcause we would normally only need 
+   		to redo the sampling bit and the final nonlinearity
+   		We can make this efficient later
+   		"""
+   		samples_measurement = []
+   		for ns in range(n_samples):
+    		distribution_measurement += self.condition(h=h, test_ligand_concentration=test_ligand_concentration, kwargs)
+    		samples_measurement.append(distribution_measurement.sample())
+    	return samples_measurement
+
+
     def marginal_loss(self, h=None, y=None, test_ligand_concentration=1e-3, n_samples=10, **kwargs):
     	"""
     	sample n_samples often from loss in order to get a better approximation

--- a/pinot/regressors/biophysical_regressor.py
+++ b/pinot/regressors/biophysical_regressor.py
@@ -1,0 +1,69 @@
+# =============================================================================
+# IMPORTS
+# =============================================================================
+import torch
+import pinot
+import abc
+import math
+from pinot.regressors.base_regressor import BaseRegressor
+from pinot.regressors.gaussian_process_regressor import ExactGaussianProcessRegressor
+from pinot.regressors.neural_network_regressor import NeuralNetworkRegressor
+
+# import gpytorch
+import numpy as np
+
+class BiophysicalRegressor(torch.nn.Module):
+    r""" Biophysically inspired model
+
+    Parameters
+    ----------
+
+    log_sigma : `float`
+        ..math:: \log\sigma observation noise
+
+    base_regressor : a regressor object that generates a latent F
+
+
+    """
+
+    def __init__(self, base_regressor=None):
+        super(BiophysicalRegressor, self).__init__()
+        self.base_regressor = base_regressor
+        self.log_sigma_measurement = torch.zeros(1)
+
+
+	def g(self, func_value=None, test_ligand_concentration=1e3-):
+	    return 1 / (1 + torch.exp(-func_value) / test_ligand_concentration)
+
+
+	def condition(self, h=None, test_ligand_concentration=1e-3, **kwargs):
+        distribution_base_regressor = self.base_regressor.condition(h, kwargs)
+
+        #we sample from the latent f to paush things through the likelihood
+        #Note: if we do this, in order to get good estimates of LLK we may need to draw multiple samples
+        f_sample = distribution_base_regressor.rsample()
+
+        mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
+        sigma_m = torch.exp(self.log_sigma_measurement)
+
+        distribution_measurement = torch.distributions.normal.Normal(loc=mu_m, scale=sigma_m)
+
+        return distribution_measurement
+
+
+    def loss(self, h=None, y=None, test_ligand_concentration=1e-3, **kwargs):
+    	distribution_measurement = self.condition(h=h, test_ligand_concentration=test_ligand_concentration, kwargs)
+    	loss_measurement = -distribution_measurement.log_prob(y)
+    	return loss_measurement
+
+
+    def marginal_loss(self, h=None, y=None, test_ligand_concentration=1e-3, n_samples=10, **kwargs):
+    	"""
+    	sample n_samples often from loss in order to get a better approximation
+    	"""
+    	marginal_loss_measurement = 0
+    	for ns in range(n_samples):
+    		marginal_loss_measurement += self.loss(h=h, y=y, test_ligand_concentration=test_ligand_concentration, kwargs)
+    	marginal_loss_measurement/=n_samples
+    	return marginal_loss_measurement
+

--- a/pinot/regressors/biophysical_regressor.py
+++ b/pinot/regressors/biophysical_regressor.py
@@ -67,7 +67,6 @@ class BiophysicalRegressor(torch.nn.Module):
     	distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
     	marginal_loss_measurement = 0
     	for ns in range(n_samples):
-    		for ns in range(n_samples):
    			f_sample = distribution_base_regressor.rsample()
 	        mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
 	        sigma_m = torch.exp(self.log_sigma_measurement)

--- a/pinot/regressors/biophysical_regressor.py
+++ b/pinot/regressors/biophysical_regressor.py
@@ -48,30 +48,30 @@ class BiophysicalRegressor(torch.nn.Module):
 		return loss_measurement
 
 
-   	def marginal_sample(self, h=None, n_samples=100, test_ligand_concentration=1e-3, **kwargs):
-   		distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
-   		samples_measurement = []
-   		for ns in range(n_samples):
-   			f_sample = distribution_base_regressor.rsample()
-	        mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
-	        sigma_m = torch.exp(self.log_sigma_measurement)
-	        distribution_measurement = torch.distributions.normal.Normal(loc=mu_m, scale=sigma_m)
-    		samples_measurement.append(distribution_measurement.sample())
-    	return samples_measurement
+	def marginal_sample(self, h=None, n_samples=100, test_ligand_concentration=1e-3, **kwargs):
+		distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
+		samples_measurement = []
+		for ns in range(n_samples):
+			f_sample = distribution_base_regressor.rsample()
+			mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
+			sigma_m = torch.exp(self.log_sigma_measurement)
+			distribution_measurement = torch.distributions.normal.Normal(loc=mu_m, scale=sigma_m)
+			samples_measurement.append(distribution_measurement.sample())
+		return samples_measurement
 
 
-    def marginal_loss(self, h=None, y=None, test_ligand_concentration=1e-3, n_samples=10, **kwargs):
-    	"""
-    	sample n_samples often from loss in order to get a better approximation
-    	"""
-    	distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
-    	marginal_loss_measurement = 0
-    	for ns in range(n_samples):
-   			f_sample = distribution_base_regressor.rsample()
-	        mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
-	        sigma_m = torch.exp(self.log_sigma_measurement)
-	        distribution_measurement = torch.distributions.normal.Normal(loc=mu_m, scale=sigma_m)
-	        marginal_loss_measurement += -distribution_measurement.log_prob(y)
-    	marginal_loss_measurement/=n_samples
-    	return marginal_loss_measurement
+	def marginal_loss(self, h=None, y=None, test_ligand_concentration=1e-3, n_samples=10, **kwargs):
+		"""
+		sample n_samples often from loss in order to get a better approximation
+		"""
+		distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
+		marginal_loss_measurement = 0
+		for ns in range(n_samples):
+			f_sample = distribution_base_regressor.rsample()
+			mu_m = self.g(func_value=f_sample, test_ligand_concentration=test_ligand_concentration)
+			sigma_m = torch.exp(self.log_sigma_measurement)
+			distribution_measurement = torch.distributions.normal.Normal(loc=mu_m, scale=sigma_m)
+			marginal_loss_measurement += -distribution_measurement.log_prob(y)
+		marginal_loss_measurement/=n_samples
+		return marginal_loss_measurement
 

--- a/pinot/regressors/biophysical_regressor.py
+++ b/pinot/regressors/biophysical_regressor.py
@@ -49,7 +49,7 @@ class BiophysicalRegressor(torch.nn.Module):
 
 
    	def marginal_sample(self, h=None, n_samples=100, test_ligand_concentration=1e-3, **kwargs):
-   		distribution_base_regressor = self.base_regressor.condition(h, kwargs)
+   		distribution_base_regressor = self.base_regressor.condition(h, **kwargs)
    		samples_measurement = []
    		for ns in range(n_samples):
    			f_sample = distribution_base_regressor.rsample()


### PR DESCRIPTION
Adding a biophysical likelihood to our regression suite so we can regress models according to the concentrations etc, but actually regress deltaG under the hood.

This is the initial PR, I do not expect tp merge that until we have working examples, so let's leave it up here for a bit.

Design principles:
This model currently lives in regressors.
One needs to pass a regressor (i.e. GP, NN) into this model which is the base_regressor and is used to model deltaG.
On top of that, a deterministic transformation is applied to samples from that regressor to transform the latent deltaG into a measurement. Finally, we have homoschedastic noise on top of the measurement.

This model should work fine with either GP or NN regressors as base_regressors and should be usale anywhere where we currently use regressors in our codebase as the interface is consistent.

@yuanqing-wang  and @miretchin you guys can have a look.