### PR TITLE
Gpytorch integration - variational GP

### DIFF
--- a/pinot/app/experiment.py
+++ b/pinot/app/experiment.py
@@ -212,7 +212,7 @@ class Test:
                 results[metric.__name__][state_name] = (
                     metric(
                         self.net,
-                        g,
+                        pinot.metrics._independent(self.net.condition(g)),
                         y,
                         *_args,
                         sampler=self.sampler,

--- a/pinot/net.py
+++ b/pinot/net.py
@@ -241,7 +241,6 @@ class Net(BaseNet):
             h_last = self.representation(self.g_last)
             kwargs = {**{"x_tr": h_last, "y_tr": self.y_last}, **kwargs}
 
-
         if sampler is not None and hasattr(sampler, 'sample_params'):
             sampler.sample_params()
         

--- a/pinot/regressors/__init__.py
+++ b/pinot/regressors/__init__.py
@@ -8,3 +8,5 @@ from pinot.regressors import biophysical_regressor
 from pinot.regressors.neural_network_regressor import *
 from pinot.regressors.gaussian_process_regressor import *
 from pinot.regressors.biophysical_regressor import BiophysicalRegressor
+
+from pinot.regressors.gpytorch_regressor import ExactGaussianProcesses, VariationalGP

--- a/pinot/regressors/__init__.py
+++ b/pinot/regressors/__init__.py
@@ -9,4 +9,4 @@ from pinot.regressors.neural_network_regressor import *
 from pinot.regressors.gaussian_process_regressor import *
 from pinot.regressors.biophysical_regressor import BiophysicalRegressor
 
-from pinot.regressors.gpytorch_regressor import ExactGaussianProcesses, VariationalGP
+from pinot.regressors.gpytorch_regressor import VariationalGP

--- a/pinot/regressors/gpytorch_regressor.py
+++ b/pinot/regressors/gpytorch_regressor.py
@@ -1,0 +1,109 @@
+import torch
+import math
+import gpytorch
+from gpytorch.variational import CholeskyVariationalDistribution
+from gpytorch.variational import VariationalStrategy
+from gpytorch.models import ApproximateGP, ExactGP
+
+
+class ExactGaussianProcesses(ExactGP):
+    def __init__(self, in_features, num_data, mean=None, covar=None):
+        # Can replace this with MultiTaskGaussianLikelihood when one wishes to use MultiTaskGP
+        likelihood = gpytorch.likelihoods.GaussianLikelihood()
+        temp_x = torch.zeros(num_data, in_features)
+        temp_y = torch.zeros(num_data, 1)
+        super(ExactGaussianProcesses, self).__init__(temp_x, temp_y, likelihood)
+        self.mean_module = gpytorch.means.LinearMean(in_features) if mean is None else mean
+        self.covar_module = gpytorch.kernels.RBFKernel() if covar is None else covar
+        self.num_data = num_data
+
+    def forward(self, h):
+        mean_x = self.mean_module(h)
+        covar_x = self.covar_module(h)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+    def loss(self, h, y, *args, **kwargs):
+        """
+        Compute the negative log likelihood
+        :param h:
+        :param y:
+        :return:
+        """
+        self.set_train_data(h, y) # Only set new data during training
+        dist_f = self(h, *args, **kwargs)  # The predictive distribution
+        llh = self.likelihood(dist_f)  # Compute the likelihood distribution
+        return -llh.log_prob(y)  # Compute negative log likelihood of the observed labels
+
+    def condition(self, h, *args, **kwargs):
+        """
+        Returns the conditional distribution p(f|x)
+        :param h:
+        :return:
+        """
+        dist = self(h, *args, **kwargs)
+        return dist
+
+
+class VariationalGP(ApproximateGP):
+    def __init__(self, in_features, num_data, inducing_points=None, num_inducing_points=100,
+                 mean=None, covar=None, beta=1.0):
+        if inducing_points is None:
+            # Randomly initialize inducing points
+            inducing_points = torch.rand(num_inducing_points, in_features)
+
+        variational_distribution = CholeskyVariationalDistribution(
+            inducing_points.size(-2)
+        )
+
+        # LMCVariationalStrategy for introducing correlation among tasks if we want MultiTaskGP
+        variational_strategy = VariationalStrategy(
+            self, inducing_points, variational_distribution, learn_inducing_locations=True
+        )
+        super(VariationalGP, self).__init__(variational_strategy)
+        self.mean_module = gpytorch.means.LinearMean(in_features) if mean is None else mean
+        self.covar_module = gpytorch.kernels.ScaleKernel(
+            gpytorch.kernels.RBFKernel(
+                lengthscale_prior=gpytorch.priors.SmoothedBoxPrior(
+                    math.exp(-1), math.exp(1), sigma=0.1, transform=torch.exp
+                )
+            )
+        ) if covar is None else covar
+        self.num_inducing = inducing_points.size(-2)
+        self.likelihood = gpytorch.likelihoods.GaussianLikelihood()
+        self.num_data = num_data
+        self.beta = beta
+
+    def forward(self, h):
+        """
+
+        :param h:
+        :return:
+        """
+        mean_x = self.mean_module(h)
+        covar_x = self.covar_module(h)
+        return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+    def loss(self, h, y, *args, **kwargs):
+        """
+        Computes the negative ELBO
+        :param h:
+        :param y:
+        :return:
+        """
+        approximate_dist_f = self(h, *args, **kwargs)
+        num_batch = approximate_dist_f.event_shape[0]
+        # Compute the log-likelihood and the KL divergence, following the same steps as in function
+        # forward() of _ApproximateMarginalLogLikelihood
+        log_likelihood = self.likelihood.expected_log_prob(y, approximate_dist_f, **kwargs).sum(-1).div(num_batch)
+        kl_divergence = self.variational_strategy.kl_divergence().div(self.num_data).mul(self.beta)
+        elbo = log_likelihood - kl_divergence
+        return -(elbo.sum())
+
+    def condition(self, x, *args, **kwargs):
+        """ Computes the predictive distribution over y* given x*
+        :param x:
+        :return:
+        """
+        dist_f = self(x, *args, **kwargs)
+        dist_y = self.likelihood(dist_f)
+        return dist_y

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch
 matplotlib
 pandas
 numpy
+gpytorch

--- a/scripts/gp/gp_playground_gpytorch.ipynb
+++ b/scripts/gp/gp_playground_gpytorch.ipynb
@@ -20,159 +20,125 @@
     "import torch\n",
     "import gpytorch\n",
     "import pinot\n",
-    "import math\n",
-    "\n",
-    "\n",
-    "from torch.optim.lr_scheduler import MultiStepLR\n"
+    "import math\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/duc/anaconda3/envs/torch-research/lib/python3.7/site-packages/dgl/base.py:45: DGLWarning: Recommend creating graphs by `dgl.graph(data)` instead of `dgl.DGLGraph(data)`.\n",
+      "  return warnings.warn(message, category=category, stacklevel=1)\n"
+     ]
+    }
+   ],
    "source": [
-    "layer = pinot.representation.dgl_legacy.gn()\n",
-    "net = pinot.representation.Sequential(\n",
-    "    layer,\n",
-    "    [32, 'tanh', 32, 'tanh', 32, 'tanh'])"
+    "data = pinot.data.esol()\n",
+    "ds_tr, ds_te = pinot.data.utils.split(data, [4, 1])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = pinot.data.esol()\n",
-    "ds = pinot.data.utils.batch(ds, 8)\n",
-    "ds_tr, ds_te = pinot.data.utils.split(ds, [4, 1])"
+    "batch_size = 32\n",
+    "ds_tr_onebatch = pinot.data.utils.batch(ds_tr, len(ds_tr))\n",
+    "ds_tr_batched  = pinot.data.utils.batch(ds_tr, 32)\n",
+    "ds_te_onebatch = pinot.data.utils.batch(ds_te, len(ds_te))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Variational GP"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "class GaussianProcessLayer(gpytorch.models.ApproximateGP):\n",
-    "    def __init__(self, num_dim, grid_bounds=(-10., 10.), grid_size=64):\n",
-    "        variational_distribution = gpytorch.variational.CholeskyVariationalDistribution(\n",
-    "            num_inducing_points=grid_size, batch_shape=torch.Size([num_dim])\n",
-    "        )\n",
-    "        \n",
-    "        # Our base variational strategy is a GridInterpolationVariationalStrategy,\n",
-    "        # which places variational inducing points on a Grid\n",
-    "        # We wrap it with a MultitaskVariationalStrategy so that our output is a vector-valued GP\n",
-    "        variational_strategy = gpytorch.variational.MultitaskVariationalStrategy(\n",
-    "            gpytorch.variational.GridInterpolationVariationalStrategy(\n",
-    "                self, grid_size=grid_size, grid_bounds=[grid_bounds],\n",
-    "                variational_distribution=variational_distribution,\n",
-    "            ), num_tasks=num_dim,\n",
-    "        )\n",
-    "        super().__init__(variational_strategy)\n",
-    "        \n",
-    "        self.covar_module = gpytorch.kernels.ScaleKernel(\n",
-    "            gpytorch.kernels.RBFKernel(\n",
-    "                lengthscale_prior=gpytorch.priors.SmoothedBoxPrior(\n",
-    "                    math.exp(-1), math.exp(1), sigma=0.1, transform=torch.exp\n",
-    "                )\n",
-    "            )\n",
-    "        )\n",
-    "        self.mean_module = gpytorch.means.ConstantMean()\n",
-    "        self.grid_bounds = grid_bounds\n",
+    "def rmse(y, yhat):\n",
+    "    return torch.sqrt(torch.mean((y.flatten()-yhat.flatten())**2))\n",
     "\n",
-    "    def forward(self, x):\n",
-    "        mean = self.mean_module(x)\n",
-    "        covar = self.covar_module(x)\n",
-    "        return gpytorch.distributions.MultivariateNormal(mean, covar)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class DKLModel(gpytorch.Module):\n",
-    "    def __init__(self, feature_extractor, num_dim, grid_bounds=(-10., 10.)):\n",
-    "        super(DKLModel, self).__init__()\n",
-    "        self.feature_extractor = feature_extractor\n",
-    "        self.gp_layer = GaussianProcessLayer(num_dim=num_dim, grid_bounds=grid_bounds)\n",
-    "        self.grid_bounds = grid_bounds\n",
-    "        self.num_dim = num_dim\n",
+    "def run_experiment(num_inducing, kernel_name=None, kernel_params=None, mean_name=\"LinearMean\", beta=1.0, device=\"cpu\", n_epochs=50):\n",
+    "    dev = torch.device(device)\n",
+    "    net_variational_gp = pinot.Net(\n",
+    "        pinot.representation.Sequential(\n",
+    "            pinot.representation.dgl_legacy.gn(kwargs={\"allow_zero_in_degree\":True}),\n",
+    "                [64, 'relu', 64, 'relu', 64, 'relu']),\n",
+    "        output_regressor_class=pinot.regressors.VariationalGP,\n",
+    "        num_inducing_points=num_inducing,\n",
+    "        num_data=902,\n",
+    "        beta = beta,\n",
+    "        covar = getattr(gpytorch.kernels, kernel_name)(**kernel_params) if kernel_name is not None else None\n",
+    "    ).to(dev)\n",
+    "    \n",
+    "    lr = 1e-4\n",
+    "    optimizer = torch.optim.Adam([\n",
+    "        {'params': net_variational_gp.representation.parameters(), 'weight_decay': 1e-4},\n",
+    "        {'params': net_variational_gp.output_regressor.parameters(), 'lr': lr*0.1}\n",
+    "    ], lr=lr)\n",
     "\n",
-    "    def forward(self, x):\n",
-    "        features = self.feature_extractor(x)\n",
-    "        features = gpytorch.utils.grid.scale_to_bounds(features, self.grid_bounds[0], self.grid_bounds[1])\n",
-    "        # This next line makes it so that we learn a GP for each feature\n",
-    "        features = features.transpose(-1, -2).unsqueeze(-1)\n",
-    "        res = self.gp_layer(features)\n",
-    "        return res"
+    "    for n in range(n_epochs):\n",
+    "        total_loss = 0.\n",
+    "        for (g, y) in ds_tr_onebatch:\n",
+    "            optimizer.zero_grad()\n",
+    "            loss = net_variational_gp.loss(g.to(dev), y.flatten().to(dev))\n",
+    "            loss.backward()\n",
+    "            optimizer.step()\n",
+    "            total_loss += loss.item()\n",
+    "            \n",
+    "    train_rmse = rmse(net_variational_gp.condition(ds_tr_onebatch[0][0].to(dev)).mean.cpu(), ds_tr_onebatch[0][1])\n",
+    "    test_rmse = rmse(net_variational_gp.condition(ds_te_onebatch[0][0].to(dev)).mean.cpu(), ds_te_onebatch[0][1])\n",
+    "    del net_variational_gp\n",
+    "    print(f\"Train rmse = {train_rmse}, test rmse = {test_rmse} for {kernel_name} kernel, beta = {beta}, num_inducing_points = {num_inducing}, mean = {mean_name}\")\n",
+    "\n",
+    "    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = DKLModel(net, num_dim=32)\n",
-    "likelihood = gpytorch.likelihoods.GaussianLikelihood()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "optimizer = torch.optim.Adam(model.parameters(), 1e-5)\n",
-    "# scheduler = MultiStepLR(optimizer, milestones=[0.5 * n_epochs, 0.75 * n_epochs], gamma=0.1)\n",
-    "mll = gpytorch.mlls.VariationalELBO(likelihood, model.gp_layer, num_data=len(ds_tr))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MultitaskMultivariateNormal(loc: torch.Size([256]))\n"
-     ]
-    },
-    {
-     "ename": "RuntimeError",
-     "evalue": "shape '[8, 8, 32]' is invalid for input of size 256",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-55-aaaf499a6584>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 8\u001b[0;31m     \u001b[0mloss\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m-\u001b[0m\u001b[0mmll\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0my_hat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      9\u001b[0m     \u001b[0mloss\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbackward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m     \u001b[0moptimizer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/pinot/lib/python3.7/site-packages/gpytorch/module.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *inputs, **kwargs)\u001b[0m\n\u001b[1;32m     26\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     27\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 28\u001b[0;31m         \u001b[0moutputs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mforward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     29\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     30\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0m_validate_module_outputs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0moutput\u001b[0m \u001b[0;32min\u001b[0m \u001b[0moutputs\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/pinot/lib/python3.7/site-packages/gpytorch/mlls/variational_elbo.py\u001b[0m in \u001b[0;36mforward\u001b[0;34m(self, variational_dist_f, target, **kwargs)\u001b[0m\n\u001b[1;32m     75\u001b[0m         \u001b[0;34m:\u001b[0m\u001b[0;32mreturn\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mVariational\u001b[0m \u001b[0mELBO\u001b[0m\u001b[0;34m.\u001b[0m \u001b[0mOutput\u001b[0m \u001b[0mshape\u001b[0m \u001b[0mcorresponds\u001b[0m \u001b[0mto\u001b[0m \u001b[0mbatch\u001b[0m \u001b[0mshape\u001b[0m \u001b[0mof\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0minput\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     76\u001b[0m         \"\"\"\n\u001b[0;32m---> 77\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mforward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariational_dist_f\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/anaconda3/envs/pinot/lib/python3.7/site-packages/gpytorch/mlls/_approximate_mll.py\u001b[0m in \u001b[0;36mforward\u001b[0;34m(self, approximate_dist_f, target, **kwargs)\u001b[0m\n\u001b[1;32m     55\u001b[0m         \u001b[0;31m# Get likelihood term and KL term\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m         \u001b[0mnum_batch\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mapproximate_dist_f\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mevent_shape\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 57\u001b[0;31m         \u001b[0mlog_likelihood\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_log_likelihood_term\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mapproximate_dist_f\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdiv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnum_batch\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     58\u001b[0m         \u001b[0mkl_divergence\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmodel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvariational_strategy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkl_divergence\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdiv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnum_data\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbeta\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/pinot/lib/python3.7/site-packages/gpytorch/mlls/variational_elbo.py\u001b[0m in \u001b[0;36m_log_likelihood_term\u001b[0;34m(self, variational_dist_f, target, **kwargs)\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     60\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_log_likelihood_term\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvariational_dist_f\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 61\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlikelihood\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpected_log_prob\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvariational_dist_f\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     62\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     63\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mforward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvariational_dist_f\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtarget\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/pinot/lib/python3.7/site-packages/gpytorch/likelihoods/gaussian_likelihood.py\u001b[0m in \u001b[0;36mexpected_log_prob\u001b[0;34m(self, target, input, *params, **kwargs)\u001b[0m\n\u001b[1;32m     41\u001b[0m         \u001b[0mnoise\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_shaped_noise_covar\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmean\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0mparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdiag\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     42\u001b[0m         \u001b[0;31m# Potentially reshape the noise to deal with the multitask case\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 43\u001b[0;31m         \u001b[0mnoise\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnoise\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mview\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mnoise\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0minput\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mevent_shape\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     44\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     45\u001b[0m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtarget\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0mmean\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m**\u001b[0m \u001b[0;36m2\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mvariance\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mnoise\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mnoise\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mmath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m2\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mmath\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpi\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: shape '[8, 8, 32]' is invalid for input of size 256"
+      "Train rmse = 0.8605661392211914, test rmse = 0.7832201719284058 for None kernel, beta = 1.0, num_inducing_points = 200, mean = LinearMean\n",
+      "Train rmse = 0.7850788831710815, test rmse = 0.7508814334869385 for None kernel, beta = 1.0, num_inducing_points = 400, mean = LinearMean\n",
+      "Train rmse = 0.8468971848487854, test rmse = 0.8037276268005371 for None kernel, beta = 1.0, num_inducing_points = 600, mean = LinearMean\n"
      ]
     }
    ],
    "source": [
-    "for g, y in ds_tr:\n",
-    "    optimizer.zero_grad()\n",
-    "    y_hat = model(g)\n",
+    "for (kernel_name, kernel_params) in [\n",
+    "        (None, None),\n",
+    "        (\"PolynomialKernel\", {\"power\":3}),\n",
+    "        (\"RBFKernel\", {})\n",
+    "    ]:\n",
     "    \n",
-    "    print(y_hat)\n",
-    "    \n",
-    "    \n",
-    "    loss = -mll(y_hat, y)\n",
-    "    loss.backward()\n",
-    "    optimizer.step()"
+    "    for num_inducing in [200, 400, 600]:\n",
+    "        run_experiment(num_inducing, kernel_name, kernel_params, device=\"cuda\", n_epochs=2000)\n",
+    "    "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -198,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/scripts/gp/variational_gpytorch_dgkl.ipynb
+++ b/scripts/gp/variational_gpytorch_dgkl.ipynb
@@ -1,0 +1,287 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using backend: pytorch\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import torch\n",
+    "import gpytorch\n",
+    "import pinot\n",
+    "import math"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/duc/anaconda3/envs/torch-research/lib/python3.7/site-packages/dgl/base.py:45: DGLWarning: Recommend creating graphs by `dgl.graph(data)` instead of `dgl.DGLGraph(data)`.\n",
+      "  return warnings.warn(message, category=category, stacklevel=1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = pinot.data.esol()\n",
+    "ds_tr, ds_te = pinot.data.utils.split(data, [4, 1])\n",
+    "\n",
+    "batch_size = 32\n",
+    "ds_tr_onebatch = pinot.data.utils.batch(ds_tr, len(ds_tr))\n",
+    "ds_tr_batched  = pinot.data.utils.batch(ds_tr, 32)\n",
+    "ds_te_onebatch = pinot.data.utils.batch(ds_te, len(ds_te))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rmse(y, yhat):\n",
+    "    return torch.sqrt(torch.mean((y.flatten()-yhat.flatten())**2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class GaussianProcessLayer(gpytorch.models.ApproximateGP):\n",
+    "    def __init__(self, in_features, grid_bounds=(-10., 10.), grid_size=150):\n",
+    "        \n",
+    "        inducing_points = torch.rand(grid_size, in_features)\n",
+    "\n",
+    "        variational_distribution = gpytorch.variational.CholeskyVariationalDistribution(\n",
+    "            grid_size\n",
+    "        )\n",
+    "\n",
+    "        # LMCVariationalStrategy for introducing correlation among tasks if we want MultiTaskGP\n",
+    "        variational_strategy = gpytorch.variational.VariationalStrategy(\n",
+    "            self, inducing_points, variational_distribution, learn_inducing_locations=True\n",
+    "        )\n",
+    "    \n",
+    "        super().__init__(variational_strategy)\n",
+    "        \n",
+    "        self.covar_module = gpytorch.kernels.RBFKernel()\n",
+    "#         self.covar_module = gpytorch.kernels.ScaleKernel(\n",
+    "#             gpytorch.kernels.RBFKernel(\n",
+    "#                 lengthscale_prior=gpytorch.priors.SmoothedBoxPrior(\n",
+    "#                     math.exp(-1), math.exp(1), sigma=0.1, transform=torch.exp\n",
+    "#                 )\n",
+    "#             )\n",
+    "#         )\n",
+    "        self.mean_module = gpytorch.means.LinearMean(in_features)\n",
+    "        self.grid_bounds = grid_bounds\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "#         print(\"GP.forward.x.shape\", x.shape)\n",
+    "        mean = self.mean_module(x)\n",
+    "        covar = self.covar_module(x)\n",
+    "        return gpytorch.distributions.MultivariateNormal(mean, covar)\n",
+    "    \n",
+    "        \n",
+    "class DKLModel(gpytorch.Module):\n",
+    "    def __init__(self, feature_extractor, num_dim, grid_bounds=(-10., 10.)):\n",
+    "        super(DKLModel, self).__init__()\n",
+    "        self.feature_extractor = feature_extractor\n",
+    "        self.gp_layer = GaussianProcessLayer(in_features=num_dim, grid_bounds=grid_bounds)\n",
+    "        self.grid_bounds = grid_bounds\n",
+    "        self.num_dim = num_dim\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        features = self.feature_extractor(x)\n",
+    "#         features = gpytorch.utils.grid.scale_to_bounds(features, self.grid_bounds[0], self.grid_bounds[1])\n",
+    "#         print(features.shape)\n",
+    "        # This next line makes it so that we learn a GP for each feature\n",
+    "        res = self.gp_layer(features)\n",
+    "        return res\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "58.350440979003906 tensor(32.9760, grad_fn=<SqrtBackward>) tensor(32.3698, grad_fn=<SqrtBackward>)\n",
+      "3.7204818725585938 tensor(1.7835, grad_fn=<SqrtBackward>) tensor(1.7496, grad_fn=<SqrtBackward>)\n",
+      "3.073115825653076 tensor(1.5075, grad_fn=<SqrtBackward>) tensor(1.4545, grad_fn=<SqrtBackward>)\n",
+      "2.5964291095733643 tensor(1.2679, grad_fn=<SqrtBackward>) tensor(1.1695, grad_fn=<SqrtBackward>)\n",
+      "2.305521249771118 tensor(1.0967, grad_fn=<SqrtBackward>) tensor(0.9583, grad_fn=<SqrtBackward>)\n",
+      "2.2024986743927 tensor(1.0302, grad_fn=<SqrtBackward>) tensor(0.8661, grad_fn=<SqrtBackward>)\n",
+      "2.17500901222229 tensor(1.0126, grad_fn=<SqrtBackward>) tensor(0.8377, grad_fn=<SqrtBackward>)\n",
+      "2.1603469848632812 tensor(1.0036, grad_fn=<SqrtBackward>) tensor(0.8258, grad_fn=<SqrtBackward>)\n",
+      "2.147128105163574 tensor(0.9957, grad_fn=<SqrtBackward>) tensor(0.8181, grad_fn=<SqrtBackward>)\n",
+      "2.1337296962738037 tensor(0.9875, grad_fn=<SqrtBackward>) tensor(0.8117, grad_fn=<SqrtBackward>)\n",
+      "2.1198956966400146 tensor(0.9791, grad_fn=<SqrtBackward>) tensor(0.8058, grad_fn=<SqrtBackward>)\n",
+      "2.1056911945343018 tensor(0.9704, grad_fn=<SqrtBackward>) tensor(0.8004, grad_fn=<SqrtBackward>)\n",
+      "2.0913870334625244 tensor(0.9615, grad_fn=<SqrtBackward>) tensor(0.7956, grad_fn=<SqrtBackward>)\n",
+      "2.077392339706421 tensor(0.9529, grad_fn=<SqrtBackward>) tensor(0.7919, grad_fn=<SqrtBackward>)\n",
+      "2.0640828609466553 tensor(0.9447, grad_fn=<SqrtBackward>) tensor(0.7893, grad_fn=<SqrtBackward>)\n",
+      "2.0516226291656494 tensor(0.9371, grad_fn=<SqrtBackward>) tensor(0.7875, grad_fn=<SqrtBackward>)\n",
+      "2.0398895740509033 tensor(0.9301, grad_fn=<SqrtBackward>) tensor(0.7864, grad_fn=<SqrtBackward>)\n",
+      "2.028585433959961 tensor(0.9234, grad_fn=<SqrtBackward>) tensor(0.7854, grad_fn=<SqrtBackward>)\n",
+      "2.0173890590667725 tensor(0.9167, grad_fn=<SqrtBackward>) tensor(0.7844, grad_fn=<SqrtBackward>)\n",
+      "2.0060627460479736 tensor(0.9099, grad_fn=<SqrtBackward>) tensor(0.7833, grad_fn=<SqrtBackward>)\n",
+      "1.9944688081741333 tensor(0.9029, grad_fn=<SqrtBackward>) tensor(0.7822, grad_fn=<SqrtBackward>)\n",
+      "1.9825774431228638 tensor(0.8956, grad_fn=<SqrtBackward>) tensor(0.7813, grad_fn=<SqrtBackward>)\n",
+      "2.0243546962738037 tensor(0.8911, grad_fn=<SqrtBackward>) tensor(0.7819, grad_fn=<SqrtBackward>)\n",
+      "1.9601023197174072 tensor(0.8823, grad_fn=<SqrtBackward>) tensor(0.7796, grad_fn=<SqrtBackward>)\n",
+      "1.9491244554519653 tensor(0.8756, grad_fn=<SqrtBackward>) tensor(0.7798, grad_fn=<SqrtBackward>)\n",
+      "1.9434144496917725 tensor(0.8732, grad_fn=<SqrtBackward>) tensor(0.7798, grad_fn=<SqrtBackward>)\n",
+      "1.9317578077316284 tensor(0.8670, grad_fn=<SqrtBackward>) tensor(0.7779, grad_fn=<SqrtBackward>)\n",
+      "1.9229589700698853 tensor(0.8622, grad_fn=<SqrtBackward>) tensor(0.7788, grad_fn=<SqrtBackward>)\n",
+      "2.156182050704956 tensor(1.1923, grad_fn=<SqrtBackward>) tensor(1.1559, grad_fn=<SqrtBackward>)\n",
+      "1.9107242822647095 tensor(0.8589, grad_fn=<SqrtBackward>) tensor(0.7727, grad_fn=<SqrtBackward>)\n",
+      "1.9020005464553833 tensor(0.8542, grad_fn=<SqrtBackward>) tensor(0.7737, grad_fn=<SqrtBackward>)\n",
+      "1.8941205739974976 tensor(0.8502, grad_fn=<SqrtBackward>) tensor(0.7747, grad_fn=<SqrtBackward>)\n",
+      "1.8863844871520996 tensor(0.8463, grad_fn=<SqrtBackward>) tensor(0.7746, grad_fn=<SqrtBackward>)\n",
+      "1.92803156375885 tensor(0.8539, grad_fn=<SqrtBackward>) tensor(0.7708, grad_fn=<SqrtBackward>)\n",
+      "1.8747756481170654 tensor(0.8439, grad_fn=<SqrtBackward>) tensor(0.7674, grad_fn=<SqrtBackward>)\n",
+      "1.8667117357254028 tensor(0.8397, grad_fn=<SqrtBackward>) tensor(0.7690, grad_fn=<SqrtBackward>)\n",
+      "1.8589001893997192 tensor(0.8357, grad_fn=<SqrtBackward>) tensor(0.7691, grad_fn=<SqrtBackward>)\n",
+      "2.858248472213745 tensor(0.8812, grad_fn=<SqrtBackward>) tensor(0.8373, grad_fn=<SqrtBackward>)\n",
+      "1.8484257459640503 tensor(0.8348, grad_fn=<SqrtBackward>) tensor(0.7609, grad_fn=<SqrtBackward>)\n",
+      "1.8398350477218628 tensor(0.8299, grad_fn=<SqrtBackward>) tensor(0.7634, grad_fn=<SqrtBackward>)\n",
+      "1.8318229913711548 tensor(0.8256, grad_fn=<SqrtBackward>) tensor(0.7636, grad_fn=<SqrtBackward>)\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-27b10d3b4e72>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     25\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mds_tr_onebatch\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m         \u001b[0moptimizer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mzero_grad\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m         \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdevice\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0mloss\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m-\u001b[0m\u001b[0mmll\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflatten\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdevice\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m         \u001b[0mloss\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbackward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/module.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *inputs, **kwargs)\u001b[0m\n\u001b[1;32m     26\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     27\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 28\u001b[0;31m         \u001b[0moutputs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mforward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     29\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     30\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0m_validate_module_outputs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0moutput\u001b[0m \u001b[0;32min\u001b[0m \u001b[0moutputs\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-4-6c8bd9b31914>\u001b[0m in \u001b[0;36mforward\u001b[0;34m(self, x)\u001b[0m\n\u001b[1;32m     46\u001b[0m \u001b[0;31m#         print(features.shape)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     47\u001b[0m         \u001b[0;31m# This next line makes it so that we learn a GP for each feature\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 48\u001b[0;31m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgp_layer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfeatures\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     49\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/models/approximate_gp.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, inputs, prior, **kwargs)\u001b[0m\n\u001b[1;32m     79\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0minputs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdim\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     80\u001b[0m             \u001b[0minputs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0minputs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munsqueeze\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 81\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvariational_strategy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprior\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mprior\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/variational/variational_strategy.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, x, prior, **kwargs)\u001b[0m\n\u001b[1;32m    172\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mupdated_strategy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfill_\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    173\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 174\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprior\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mprior\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/variational/_variational_strategy.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, x, prior, **kwargs)\u001b[0m\n\u001b[1;32m    127\u001b[0m                 \u001b[0minducing_values\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mvariational_dist_u\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmean\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    128\u001b[0m                 \u001b[0mvariational_inducing_covar\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mvariational_dist_u\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlazy_covariance_matrix\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 129\u001b[0;31m                 \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    130\u001b[0m             )\n\u001b[1;32m    131\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvariational_dist_u\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDelta\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/module.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, *inputs, **kwargs)\u001b[0m\n\u001b[1;32m     26\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     27\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__call__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 28\u001b[0;31m         \u001b[0moutputs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mforward\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     29\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     30\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0m_validate_module_outputs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0moutput\u001b[0m \u001b[0;32min\u001b[0m \u001b[0moutputs\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/variational/variational_strategy.py\u001b[0m in \u001b[0;36mforward\u001b[0;34m(self, x, inducing_points, inducing_values, variational_inducing_covar, **kwargs)\u001b[0m\n\u001b[1;32m    102\u001b[0m         \u001b[0;31m# K_ZZ^{-1/2} K_ZX\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    103\u001b[0m         \u001b[0;31m# K_ZZ^{-1/2} \\mu_Z\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 104\u001b[0;31m         \u001b[0mL\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_cholesky_factor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minduc_induc_covar\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    105\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mL\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0minduc_induc_covar\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mshape\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    106\u001b[0m             \u001b[0;31m# Aggressive caching can cause nasty shape incompatibilies when evaluating with different batch shapes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/utils/memoize.py\u001b[0m in \u001b[0;36mg\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m     74\u001b[0m         \u001b[0mcache_name\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mname\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0mname\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32melse\u001b[0m \u001b[0mmethod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     75\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0m_is_in_cache_ignore_args\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 76\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0m_add_to_cache_ignore_args\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmethod\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     77\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0m_get_from_cache_ignore_args\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/variational/variational_strategy.py\u001b[0m in \u001b[0;36m_cholesky_factor\u001b[0;34m(self, induc_induc_covar)\u001b[0m\n\u001b[1;32m     71\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mcached\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"cholesky_factor\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mignore_args\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     72\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_cholesky_factor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minduc_induc_covar\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 73\u001b[0;31m         \u001b[0mL\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpsd_safe_cholesky\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdelazify\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minduc_induc_covar\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdouble\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mjitter\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msettings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcholesky_jitter\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     74\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mTriangularLazyTensor\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mL\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     75\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/torch-research/lib/python3.7/site-packages/gpytorch/utils/cholesky.py\u001b[0m in \u001b[0;36mpsd_safe_cholesky\u001b[0;34m(A, upper, out, jitter, max_tries)\u001b[0m\n\u001b[1;32m     25\u001b[0m     \"\"\"\n\u001b[1;32m     26\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 27\u001b[0;31m         \u001b[0mL\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtorch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcholesky\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mA\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mupper\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mupper\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     28\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mL\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     29\u001b[0m     \u001b[0;32mexcept\u001b[0m \u001b[0mRuntimeError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "gpu = torch.device(\"cuda\")\n",
+    "cpu = torch.device(\"cpu\")\n",
+    "device = cpu\n",
+    "\n",
+    "\n",
+    "feature_extractor = pinot.representation.Sequential(\n",
+    "        pinot.representation.dgl_legacy.gn(kwargs={\"allow_zero_in_degree\":True}),\n",
+    "        [32, 'tanh', 32, 'tanh', 32, 'tanh']).to(device)\n",
+    "\n",
+    "model = DKLModel(feature_extractor, num_dim=32).to(device)\n",
+    "likelihood = gpytorch.likelihoods.GaussianLikelihood().to(device)\n",
+    "mll = gpytorch.mlls.VariationalELBO(likelihood, model.gp_layer, num_data=902).to(device)\n",
+    "\n",
+    "\n",
+    "lr = 1e-3\n",
+    "optimizer = torch.optim.Adam([\n",
+    "    {'params': model.feature_extractor.parameters(), 'weight_decay': 1e-4},\n",
+    "    {'params': model.gp_layer.parameters(), 'lr': lr*0.1},\n",
+    "    {'params': likelihood.parameters()},\n",
+    "], lr=lr)\n",
+    "\n",
+    "\n",
+    "for n in range(5000):\n",
+    "    total_loss = 0.\n",
+    "    for (g, y) in ds_tr_onebatch:\n",
+    "        optimizer.zero_grad()\n",
+    "        output = model(g.to(device))\n",
+    "        loss = -mll(output, y.flatten().to(device))\n",
+    "        loss.backward()\n",
+    "        total_loss += loss.item()\n",
+    "        optimizer.step()\n",
+    "    \n",
+    "    if n % 100 == 0:\n",
+    "        train_rmse = rmse(model(ds_tr_onebatch[0][0]).mean.cpu(), ds_tr_onebatch[0][1])\n",
+    "        test_rmse = rmse(model(ds_te_onebatch[0][0]).mean.cpu(), ds_te_onebatch[0][1])\n",
+    "        print (total_loss, train_rmse, test_rmse)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(1.0345, grad_fn=<MeanBackward0>) tensor(0.7299, grad_fn=<MeanBackward0>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# print(model(ds_tr_onebatch[0][0]).mean)\n",
+    "\n",
+    "\n",
+    "print(train_rmse, test_rmse)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Example usage can be found in `scripts/gp/gp_playground_gpytorch.ipynb` 

```
    net_variational_gp = pinot.Net(
        pinot.representation.Sequential(
            pinot.representation.dgl_legacy.gn(kwargs={"allow_zero_in_degree":True}),
                [64, 'relu', 64, 'relu', 64, 'relu']),
        output_regressor_class=pinot.regressors.VariationalGP,
        num_inducing_points=150,
        num_data=902,
        beta = beta,
    )
    
    lr = 1e-4
    optimizer = torch.optim.Adam([
        {'params': net_variational_gp.representation.parameters(), 'weight_decay': 1e-4},
        {'params': net_variational_gp.output_regressor.parameters(), 'lr': lr*0.1}
    ], lr=lr)

    for n in range(n_epochs):
        total_loss = 0.
        for (g, y) in data:
            optimizer.zero_grad()
            loss = net_variational_gp.loss(g, y.flatten())
            loss.backward()
            optimizer.step()
            total_loss += loss.item()
```